### PR TITLE
Remove Race Condition & Allows For > 1 sec Bucket Capacity

### DIFF
--- a/openlimit/buckets/__init__.py
+++ b/openlimit/buckets/__init__.py
@@ -1,2 +1,4 @@
-from openlimit.buckets.redis_bucket import RedisBucket
 from openlimit.buckets.bucket import Bucket
+from openlimit.buckets.buckets import Buckets
+from openlimit.buckets.redis_bucket import RedisBucket
+from openlimit.buckets.redis_buckets import RedisBuckets

--- a/openlimit/buckets/buckets.py
+++ b/openlimit/buckets/buckets.py
@@ -1,0 +1,87 @@
+# Standard library
+import asyncio
+import time
+from typing import Optional
+
+from openlimit.buckets.bucket import Bucket
+
+######
+# MAIN
+######
+
+
+class Buckets(object):
+    def __init__(self, buckets: list[Bucket]) -> None:
+        self.buckets = buckets
+
+    def _get_capacities(
+        self,
+        current_time: Optional[float] = None,
+    ):
+
+        if current_time is None:
+            current_time = time.time()
+
+        new_capacities = [
+            bucket._get_capacity(current_time=current_time) for bucket in self.buckets
+        ]
+
+        return new_capacities
+
+    def _set_capacities(
+        self,
+        new_capacities: list[float],
+        current_time: Optional[float] = None,
+    ):
+
+        if current_time is None:
+            current_time = time.time()
+
+        for new_capacity, bucket in zip(new_capacities, self.buckets):
+
+            bucket._set_capacity(
+                new_capacity,
+                current_time=current_time,
+            )
+
+    def _has_capacity(self, amounts: list[float]):
+
+        # Create the current time
+        current_time = time.time()
+
+        # Get the new capacities
+        new_capacities = self._get_capacities(current_time=current_time)
+
+        # Determine if we have sufficient capacity
+        has_capacity = min(
+            [
+                amount <= new_capacity
+                for amount, new_capacity in zip(amounts, new_capacities)
+            ]
+        )
+
+        # If there is enough capacity, remove the amount
+        if has_capacity:
+            new_capacities = [
+                new_capacity - amount
+                for new_capacity, amount in zip(new_capacities, amounts)
+            ]
+
+        # Set the new capacities
+        self._set_capacities(new_capacities, current_time=current_time)
+
+        return has_capacity
+
+    def wait_for_capacity_sync(
+        self, amounts: list[float], sleep_interval: float = 1e-1
+    ):
+
+        while not self._has_capacity(amounts):
+            time.sleep(sleep_interval)
+
+    async def wait_for_capacity(
+        self, amounts: list[float], sleep_interval: float = 1e-1
+    ):
+
+        while not self._has_capacity(amounts):
+            await asyncio.sleep(sleep_interval)

--- a/openlimit/buckets/redis_bucket.py
+++ b/openlimit/buckets/redis_bucket.py
@@ -1,10 +1,12 @@
 # Standard library
 import asyncio
 import time
+import typing
 
 # Third party
 import aioredis
-
+import aioredis.client
+import aioredis.lock
 
 ######
 # MAIN
@@ -12,44 +14,72 @@ import aioredis
 
 
 class RedisBucket(object):
-    def __init__(self, rate_limit, bucket_key, redis):
+    def __init__(
+        self,
+        rate_limit,
+        bucket_key,
+        redis: aioredis.Redis,
+        bucket_size_in_seconds: float = 1,
+    ):
         # Per-second rate limit
         self._rate_per_sec = rate_limit / 60
+
+        # The integration time of the bucket
+        self._bucket_size_in_seconds = bucket_size_in_seconds
 
         # Redis
         self._redis = redis
         self._bucket_key = bucket_key
-    
-    async def _has_capacity_async(self, amount):
-        async with aioredis.lock.Lock(self._redis, f"{self._bucket_key}:lock"):
+
+    def _lock(self, **kwargs):
+
+        return aioredis.lock.Lock(self._redis, f"{self._bucket_key}:lock", **kwargs)
+
+    async def _get_capacity(
+        self,
+        pipeline: typing.Optional[aioredis.client.Pipeline] = None,
+        current_time: typing.Optional[float] = None,
+    ):
+
+        if pipeline is None:
             pipeline = self._redis.pipeline()
 
-            pipeline.get(f"{self._bucket_key}:last_checked")
-            pipeline.get(f"{self._bucket_key}:capacity")
+        pipeline.get(f"{self._bucket_key}:last_checked")
+        pipeline.get(f"{self._bucket_key}:capacity")
 
+        if current_time is None:
             current_time = asyncio.get_event_loop().time()
 
-            last_checked, capacity = await pipeline.execute()
+        last_checked, capacity = await pipeline.execute()
 
-            if not last_checked or not capacity:
-                last_checked = current_time
-                capacity = self._rate_per_sec
-            
-            time_passed = current_time - float(last_checked)
-            new_capacity = min(self._rate_per_sec, float(capacity) + time_passed * self._rate_per_sec)
+        if not last_checked or not capacity:
+            last_checked = current_time
+            capacity = self._rate_per_sec * self._bucket_size_in_seconds
 
-            pipeline.set(f"{self._bucket_key}:last_checked", current_time)
+        time_passed = current_time - float(last_checked)
+        new_capacity = min(
+            self._rate_per_sec * self._bucket_size_in_seconds,
+            float(capacity) + time_passed * self._rate_per_sec,
+        )
 
-            if new_capacity < amount:
-                pipeline.set(f"{self._bucket_key}:capacity", new_capacity)
-                await pipeline.execute()
-                return False
-            
-            pipeline.set(f"{self._bucket_key}:capacity", new_capacity - amount)
+        return new_capacity
+
+    async def _set_capacity(
+        self,
+        new_capacity: float,
+        pipeline: typing.Optional[aioredis.client.Pipeline] = None,
+        current_time: typing.Optional[float] = None,
+        execute: bool = True,
+    ):
+
+        if pipeline is None:
+            pipeline = self._redis.pipeline()
+
+        if current_time is None:
+            current_time = asyncio.get_event_loop().time()
+
+        pipeline.set(f"{self._bucket_key}:last_checked", current_time)
+        pipeline.set(f"{self._bucket_key}:capacity", new_capacity)
+
+        if execute:
             await pipeline.execute()
-
-            return True
-
-    async def wait_for_capacity(self, amount):
-        while not await self._has_capacity_async(amount):
-            await asyncio.sleep(1 / self._rate_per_sec)

--- a/openlimit/rate_limiters.py
+++ b/openlimit/rate_limiters.py
@@ -3,8 +3,7 @@ import asyncio
 
 # Local
 import openlimit.utilities as utils
-from openlimit.buckets import Bucket
-
+from openlimit.buckets import Bucket, Buckets
 
 ############
 # BASE CLASS
@@ -12,28 +11,46 @@ from openlimit.buckets import Bucket
 
 
 class RateLimiter(object):
-    def __init__(self, request_limit, token_limit, token_counter):
+    def __init__(
+        self,
+        request_limit,
+        token_limit,
+        token_counter,
+        bucket_size_in_seconds: float = 1,
+    ):
         # Rate limits
         self.request_limit = request_limit
         self.token_limit = token_limit
+        self.sleep_interval = 1 / (self.request_limit / 60)
 
         # Token counter
         self.token_counter = token_counter
 
+        # Bucket size in seconds
+        self._bucket_size_in_seconds = bucket_size_in_seconds
+
         # Buckets
-        self._request_bucket = Bucket(request_limit)
-        self._token_bucket = Bucket(token_limit)
- 
-    async def wait_for_capacity(self, num_tokens):
-        await asyncio.gather(
-            self._token_bucket.wait_for_capacity(num_tokens),
-            self._request_bucket.wait_for_capacity(1)
+        self._buckets = Buckets(
+            buckets=[
+                Bucket(request_limit, bucket_size_in_seconds),
+                Bucket(token_limit, bucket_size_in_seconds),
+            ]
         )
-    
+
+    async def wait_for_capacity(self, num_tokens):
+        await self._buckets.wait_for_capacity(
+            amounts=[1, num_tokens], sleep_interval=self.sleep_interval
+        )
+
+    def wait_for_capacity_sync(self, num_tokens):
+        self._buckets.wait_for_capacity_sync(
+            amounts=[1, num_tokens], sleep_interval=self.sleep_interval
+        )
+
     def limit(self, **kwargs):
         num_tokens = self.token_counter(**kwargs)
         return utils.ContextManager(num_tokens, self)
-    
+
     def is_limited(self):
         return utils.FunctionDecorator(self)
 
@@ -44,27 +61,39 @@ class RateLimiter(object):
 
 
 class ChatRateLimiter(RateLimiter):
-    def __init__(self, request_limit=3500, token_limit=90000):
+    def __init__(
+        self, request_limit=3500, token_limit=90000, bucket_size_in_seconds: float = 1
+    ):
         super().__init__(
             request_limit=request_limit,
             token_limit=token_limit,
-            token_counter=utils.num_tokens_consumed_by_chat_request
+            token_counter=utils.num_tokens_consumed_by_chat_request,
+            bucket_size_in_seconds=bucket_size_in_seconds,
         )
 
 
 class CompletionRateLimiter(RateLimiter):
-    def __init__(self, request_limit=3500, token_limit=350000):
+    def __init__(
+        self, request_limit=3500, token_limit=350000, bucket_size_in_seconds: float = 1
+    ):
         super().__init__(
             request_limit=request_limit,
             token_limit=token_limit,
-            token_counter=utils.num_tokens_consumed_by_completion_request
+            token_counter=utils.num_tokens_consumed_by_completion_request,
+            bucket_size_in_seconds=bucket_size_in_seconds,
         )
 
 
 class EmbeddingRateLimiter(RateLimiter):
-    def __init__(self, request_limit=3500, token_limit=70000000):
+    def __init__(
+        self,
+        request_limit=3500,
+        token_limit=70000000,
+        bucket_size_in_seconds: float = 1,
+    ):
         super().__init__(
-            request_limit=request_limit, 
-            token_limit=token_limit, 
-            token_counter=utils.num_tokens_consumed_by_embedding_request
+            request_limit=request_limit,
+            token_limit=token_limit,
+            token_counter=utils.num_tokens_consumed_by_embedding_request,
+            bucket_size_in_seconds=bucket_size_in_seconds,
         )

--- a/openlimit/redis_rate_limiters.py
+++ b/openlimit/redis_rate_limiters.py
@@ -90,7 +90,11 @@ class RateLimiterWithRedis(object):
 
 class ChatRateLimiterWithRedis(RateLimiterWithRedis):
     def __init__(
-        self, request_limit=3500, token_limit=90000, redis_url="redis://localhost:5050"
+        self,
+        request_limit=3500,
+        token_limit=90000,
+        redis_url="redis://localhost:5050",
+        bucket_size_in_seconds: float = 1,
     ):
         super().__init__(
             request_limit=request_limit,
@@ -98,12 +102,17 @@ class ChatRateLimiterWithRedis(RateLimiterWithRedis):
             token_counter=utils.num_tokens_consumed_by_chat_request,
             bucket_key="chat",
             redis_url=redis_url,
+            bucket_size_in_seconds=bucket_size_in_seconds,
         )
 
 
 class CompletionRateLimiterWithRedis(RateLimiterWithRedis):
     def __init__(
-        self, request_limit=3500, token_limit=350000, redis_url="redis://localhost:5050"
+        self,
+        request_limit=3500,
+        token_limit=350000,
+        redis_url="redis://localhost:5050",
+        bucket_size_in_seconds: float = 1,
     ):
         super().__init__(
             request_limit=request_limit,
@@ -111,6 +120,7 @@ class CompletionRateLimiterWithRedis(RateLimiterWithRedis):
             token_counter=utils.num_tokens_consumed_by_completion_request,
             bucket_key="completion",
             redis_url=redis_url,
+            bucket_size_in_seconds=bucket_size_in_seconds,
         )
 
 
@@ -120,6 +130,7 @@ class EmbeddingRateLimiterWithRedis(RateLimiterWithRedis):
         request_limit=3500,
         token_limit=70000000,
         redis_url="redis://localhost:5050",
+        bucket_size_in_seconds: float = 1,
     ):
         super().__init__(
             request_limit=request_limit,
@@ -127,4 +138,5 @@ class EmbeddingRateLimiterWithRedis(RateLimiterWithRedis):
             token_counter=utils.num_tokens_consumed_by_embedding_request,
             bucket_key="embedding",
             redis_url=redis_url,
+            bucket_size_in_seconds=bucket_size_in_seconds,
         )

--- a/openlimit/redis_rate_limiters.py
+++ b/openlimit/redis_rate_limiters.py
@@ -6,8 +6,7 @@ import aioredis
 
 # Local
 import openlimit.utilities as utils
-from openlimit.buckets import RedisBucket
-
+from openlimit.buckets import RedisBucket, RedisBuckets
 
 ############
 # BASE CLASS
@@ -15,10 +14,19 @@ from openlimit.buckets import RedisBucket
 
 
 class RateLimiterWithRedis(object):
-    def __init__(self, request_limit, token_limit, token_counter, bucket_key, redis_url="redis://localhost:5050"):
+    def __init__(
+        self,
+        request_limit,
+        token_limit,
+        token_counter,
+        bucket_key,
+        redis_url="redis://localhost:5050",
+        bucket_size_in_seconds: float = 1,
+    ):
         # Rate limits
         self.request_limit = request_limit
         self.token_limit = token_limit
+        self.sleep_interval = 1 / (self.request_limit / 60)
 
         # Token counter
         self.token_counter = token_counter
@@ -26,41 +34,51 @@ class RateLimiterWithRedis(object):
         # Redis
         self._redis_url = redis_url
 
+        # Bucket size in seconds
+        self._bucket_size_in_seconds = bucket_size_in_seconds
+
         # Buckets
-        self._request_bucket = None
-        self._token_bucket = None
+        self._buckets = None
 
         # Bucket prefix (for Redis)
         self._bucket_key = bucket_key
-    
+
     async def _init_buckets(self):
-        if self._request_bucket and self._token_bucket:
+        if self._buckets:
             return
 
-        redis = await aioredis.from_url(self._redis_url, encoding="utf-8", decode_responses=True)
-
-        self._request_bucket = RedisBucket(
-            self.request_limit,
-            bucket_key=f"{self._bucket_key}_requests",
-            redis=redis
+        redis = await aioredis.from_url(
+            self._redis_url, encoding="utf-8", decode_responses=True
         )
-        self._token_bucket = RedisBucket(
-            self.token_limit,
-            bucket_key=f"{self._bucket_key}_tokens",
-            redis=redis
+
+        self._buckets = RedisBuckets(
+            redis=redis,
+            buckets=[
+                RedisBucket(
+                    self.request_limit,
+                    bucket_key=f"{self._bucket_key}_requests",
+                    redis=redis,
+                    bucket_size_in_seconds=self._bucket_size_in_seconds,
+                ),
+                RedisBucket(
+                    self.token_limit,
+                    bucket_key=f"{self._bucket_key}_tokens",
+                    redis=redis,
+                    bucket_size_in_seconds=self._bucket_size_in_seconds,
+                ),
+            ],
         )
 
     async def wait_for_capacity(self, num_tokens):
         await self._init_buckets()
-        await asyncio.gather(
-            self._token_bucket.wait_for_capacity(num_tokens),
-            self._request_bucket.wait_for_capacity(1)
+        await self._buckets.wait_for_capacity(
+            amounts=[1, num_tokens], sleep_interval=self.sleep_interval
         )
-    
+
     def limit(self, **kwargs):
         num_tokens = self.token_counter(**kwargs)
         return utils.ContextManager(num_tokens, self)
-    
+
     def is_limited(self):
         return utils.FunctionDecorator(self)
 
@@ -71,33 +89,42 @@ class RateLimiterWithRedis(object):
 
 
 class ChatRateLimiterWithRedis(RateLimiterWithRedis):
-    def __init__(self, request_limit=3500, token_limit=90000, redis_url="redis://localhost:5050"):
+    def __init__(
+        self, request_limit=3500, token_limit=90000, redis_url="redis://localhost:5050"
+    ):
         super().__init__(
-            request_limit=request_limit, 
-            token_limit=token_limit, 
+            request_limit=request_limit,
+            token_limit=token_limit,
             token_counter=utils.num_tokens_consumed_by_chat_request,
-            bucket_key="chat", 
-            redis_url=redis_url
+            bucket_key="chat",
+            redis_url=redis_url,
         )
 
 
 class CompletionRateLimiterWithRedis(RateLimiterWithRedis):
-    def __init__(self, request_limit=3500, token_limit=350000, redis_url="redis://localhost:5050"):
+    def __init__(
+        self, request_limit=3500, token_limit=350000, redis_url="redis://localhost:5050"
+    ):
         super().__init__(
-            request_limit=request_limit, 
-            token_limit=token_limit, 
+            request_limit=request_limit,
+            token_limit=token_limit,
             token_counter=utils.num_tokens_consumed_by_completion_request,
-            bucket_key="completion", 
-            redis_url=redis_url
+            bucket_key="completion",
+            redis_url=redis_url,
         )
 
 
 class EmbeddingRateLimiterWithRedis(RateLimiterWithRedis):
-    def __init__(self, request_limit=3500, token_limit=70000000, redis_url="redis://localhost:5050"):
+    def __init__(
+        self,
+        request_limit=3500,
+        token_limit=70000000,
+        redis_url="redis://localhost:5050",
+    ):
         super().__init__(
-            request_limit=request_limit, 
-            token_limit=token_limit, 
+            request_limit=request_limit,
+            token_limit=token_limit,
             token_counter=utils.num_tokens_consumed_by_embedding_request,
-            bucket_key="embedding", 
-            redis_url=redis_url
+            bucket_key="embedding",
+            redis_url=redis_url,
         )

--- a/openlimit/utilities/context_decorators.py
+++ b/openlimit/utilities/context_decorators.py
@@ -41,8 +41,7 @@ class ContextManager(object):
         self.rate_limiter = rate_limiter
 
     def __enter__(self):
-        self.rate_limiter._request_bucket.wait_for_capacity_sync(1)
-        self.rate_limiter._token_bucket.wait_for_capacity_sync(self.num_tokens)
+        self.rate_limiter.wait_for_capacity_sync(self.num_tokens)
 
     def __exit__(self, *exc):
         return False


### PR DESCRIPTION
As written, buckets were statically capped at 1 seconds worth of capacity. This isn't how OpenAI (or most others) apply rate limits, and precludes execution of prompts with more than 1 / 60 of the tokens_per_minute limit. (i.e. if the rate limit was 60,000 tokens per minute, no request with > 1,000 tokens would be allowed through).

Additionally, with many threads referencing the same redis cache, it was possible that one thread received a lock on the `requests` index and another received a lock on the `tokens` index. By fixing the execution order, we resolve that possibility.

Also, the revised architecture allows for easy extensibility to more than just 2 types of buckets (`requests` and `tokens`).